### PR TITLE
Make second parameters truly optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ const applyAttributeToOthers = (
  */
 export const hideOthers = (
   originalTarget: Element | Element[],
-  parentNode: HTMLElement | undefined,
+  parentNode?: HTMLElement,
   markerName = 'data-aria-hidden'
 ): Undo => {
   const targets = Array.from(Array.isArray(originalTarget) ? originalTarget : [originalTarget]);
@@ -157,7 +157,7 @@ export const hideOthers = (
  */
 export const inertOthers = (
   originalTarget: Element | Element[],
-  parentNode: HTMLElement | undefined,
+  parentNode?: HTMLElement,
   markerName = 'data-inert-ed'
 ): Undo => {
   const activeParentNode = parentNode || getDefaultParent(originalTarget);
@@ -184,6 +184,6 @@ export const supportsInert = (): boolean =>
  */
 export const suppressOthers = (
   originalTarget: Element | Element[],
-  parentNode: HTMLElement | undefined,
+  parentNode?: HTMLElement,
   markerName = 'data-suppressed'
 ): Undo => (supportsInert() ? inertOthers : hideOthers)(originalTarget, parentNode, markerName);


### PR DESCRIPTION
With the recent updates to this package, I am seeing the following error when using the `hideOthers` function:
`error TS2554: Expected 2-3 arguments, but got 1.`
I believe this second argument is meant to be optional, since it allows `undefined`, but since it doesn't use a `?` or a default value, it is not optional. This issue also applies to `inertOthers` and `suppressOthers`. I think the best solution is just to add `?` and remove `| undefined`. What do you think?