### PR TITLE
feat: exclude script tags from hideOthers

### DIFF
--- a/__tests__/aria.spec.tsx
+++ b/__tests__/aria.spec.tsx
@@ -148,6 +148,30 @@ describe('Specs', () => {
     unhide();
   });
 
+  it('handles script', () => {
+    const wrapper = render(
+      <div>
+        <div>
+          <div id="to-be-hidden">hidden</div>
+          <script></script>
+        </div>
+        <div>not-hidden</div>
+      </div>
+    );
+    const root = wrapper.baseElement.firstElementChild!;
+
+    const unhide = hideOthers(root.firstElementChild!.lastElementChild!, root as any);
+
+    expect(getNearestAttribute(root.querySelector('script')!, 'aria-hidden', { current: root })).toBe(null);
+    expect(getNearestAttribute(root.querySelector('#to-be-hidden')!, 'aria-hidden', { current: root })).toBe('true');
+
+    expect(wrapper.baseElement.innerHTML).toMatchInlineSnapshot(
+      `"<div><div><div><div id=\\"to-be-hidden\\" data-aria-hidden=\\"true\\" aria-hidden=\\"true\\">hidden</div><script></script></div><div>not-hidden</div></div></div>"`
+    );
+
+    unhide();
+  });
+
   it('works on IE11', () => {
     // Simulate IE11 DOM Node implementation.
     HTMLElement.prototype.contains = Node.prototype.contains;

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,8 +168,9 @@ export const hideOthers = (
     return () => null;
   }
 
-  // we should not hide ariaLive elements - https://github.com/theKashey/aria-hidden/issues/10
-  targets.push(...Array.from(activeParentNode.querySelectorAll('[aria-live]')));
+  // we should not hide aria-live elements - https://github.com/theKashey/aria-hidden/issues/10
+  // and script elements, as they have no impact on accessibility.
+  targets.push(...Array.from(activeParentNode.querySelectorAll('[aria-live], script')));
 
   return applyAttributeToOthers(targets, activeParentNode, markerName, 'aria-hidden');
 };


### PR DESCRIPTION
Script tags should not have the `aria-hidden` attribute, as it provides no benefit and can negatively impact performance. In many modern frameworks, the root body element often contains multiple script tags, leading to a noticeable performance decrease.

This PR excludes those tags and adds a test to ensure proper coverage.